### PR TITLE
Gemini API 기반 감정 분류 기능 구현

### DIFF
--- a/src/main/java/com/emomap/emomap/global/config/HttpClientsConfig.java
+++ b/src/main/java/com/emomap/emomap/global/config/HttpClientsConfig.java
@@ -1,6 +1,5 @@
 package com.emomap.emomap.global.config;               // 전역 설정 패키지
 
-
 import org.springframework.beans.factory.annotation.Value;  // 키랑 모델 읽을 때 @Value로 가져옴
 import org.springframework.context.annotation.Bean;       // @Bean 등록
 import org.springframework.context.annotation.Configuration; // 설정 클래스 표시
@@ -10,11 +9,11 @@ import org.springframework.web.reactive.function.client.WebClient; // HTTP 클�
 @Configuration
 public class HttpClientsConfig {
 
-    @Bean                                               // openAiClient
-    public WebClient openAiClient(@Value("${app.openai.api-key}") String key) { // 환경변수에서 키 가져옴
+    @Bean
+    public WebClient geminiClient(@Value("${app.gemini.api-key}") String apiKey) {
+        // Gemini API 호출 시 key를 queryParam으로 붙이기 위해서 baseUrl에는 key까지 포함함
         return WebClient.builder()
-                .baseUrl("https://api.openai.com/v1")   // OpenAI API 기본 URL
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + key) // 인증 헤더
+                .baseUrl("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=" + apiKey)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE) // JSON 요청
                 .build();
     }

--- a/src/main/java/com/emomap/emomap/post/service/Emotion.java
+++ b/src/main/java/com/emomap/emomap/post/service/Emotion.java
@@ -1,77 +1,93 @@
-package com.emomap.emomap.post.service;   // 포스트 관련 서비스 패키지
+package com.emomap.emomap.post.service;
 
-import com.fasterxml.jackson.databind.JsonNode;   // JSON 파싱용 Jackson
-import lombok.RequiredArgsConstructor;           // final 필드 생성자 자동 주입 lombok
-import org.springframework.beans.factory.annotation.Value; // yml에서 값 받기
-import org.springframework.stereotype.Service;   // 서비스 빈 등록
-import org.springframework.web.reactive.function.client.WebClient; // HTTP 호출 클라이언트
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.*;                               // List, Map 등
-import java.util.stream.Collectors;               // 스트림을 문자열 변환 해줌
+import java.util.List;
+import java.util.Map;
 
-@Service                                         // 이 클래스가 서비스 레이어임
-@RequiredArgsConstructor                         // final 필드 자동 생성자
+@Service
+@RequiredArgsConstructor
 public class Emotion {
 
-    private final WebClient openAiClient;        // OpenAI API 호출용 WebClient
+    // gemini api 호출용 webclient
+    private final WebClient geminiClient;
 
-    @Value("${app.openai.model}")
-    private String model;                        // 사용할 GPT 모델명
-
-    // 사용할 수 있는 감정 코드들 미리 고정
+    // 감정 태그 허용 목록
     private static final List<String> ALLOWED = List.of(
             "friendship","nostalgia","family","comfort","excitement","lonely"
     );
 
-    /* emotions가 비어있을 때 GPT 호출해서 "code1,code2" 형태로 반환 */
+    // 감정 태그가 비어 있으면 ai로 분류
     public String classifyIfBlank(String content, String emotionsNullable) {
-        // 이미 emotions가 들어있으면 GPT 안 불러도 되니까 그대로 반환함
-        if (emotionsNullable != null && !emotionsNullable.isBlank()) return emotionsNullable;
 
-        /**
-        // GPT한테 역할 설명: 1~3개 감정 코드만 뽑아달라는 말
-        String sys = """
-            You are an emotion tagger. Pick 1~3 tags that best fit the text.
-            Allowed codes: friendship, nostalgia, family, comfort, excitement, lonely.
-            Return ONLY comma-separated codes without spaces or explanations.
-            """;
-        // 실제 본문 내용 전달해줌
-        String user = "text: " + content;
+        // 사용자가 감정 태그를 직접 넣은 경우에는 그대로 쓰게 함
+        if (emotionsNullable != null && !emotionsNullable.isBlank()) {
+            return emotionsNullable.trim();
+        }
 
-        // OpenAI API에 보낼 요청 바디 구성
+        // gemini에 보낼 프롬프트
+        String prompt = """
+                You are an emotion tagger. Pick 1~3 tags that best fit the text.
+                Allowed: friendship, nostalgia, family, comfort, excitement, lonely.
+                Return ONLY comma-separated codes, no spaces, no explanations.
+                Text: %s
+                """.formatted(content);
+
+        // gemini api 요청 json
         Map<String, Object> req = Map.of(
-                "model", model, // 사용할 모델명
-                "messages", List.of(
-                        Map.of("role", "system", "content", sys), // 역할 정의
-                        Map.of("role", "user", "content", user)   // 실제 본문
-                ),
-                "temperature", 0 // 랜덤 없이 딱 정해진 태그 뽑게 함
+                "contents", List.of(
+                        Map.of("parts", List.of(
+                                Map.of("text", prompt)
+                        ))
+                )
         );
 
-        // WebClient로 OpenAI API 호출
-        String raw = openAiClient.post()             // POST 요청
-                .uri("/chat/completions")            // 채팅 완성 API 엔드포인트
-                .bodyValue(req)                      // 요청 바디 세팅
-                .retrieve()                          // 응답 가져오기
-                .bodyToMono(JsonNode.class)          // JSON으로 변환
-                .map(n -> n.at("/choices/0/message/content").asText("")) // 응답에서 결과 텍스트만 추출
-                .block();                            // 동기식으로 결과를 받을 때까지 대기
+        try {
+            // gemini api 호출
+            @SuppressWarnings("unchecked")
+            Map<String, Object> resp = geminiClient.post()
+                    .bodyValue(req)              // 요청 바디
+                    .retrieve()                  // 응답 가져오기
+                    .bodyToMono(Map.class)       // Map 형태로 변환시킴
+                    .block();                    // 동기 방식으로 기다림
 
-        // 응답이 null이면 기본값 default 반환
-        if (raw == null) return "default";
+            // 응답에서 감정 태그만 뽑는 것임
+            String out = "";
+            if (resp != null) {
+                var candidates = (List<Map<String, Object>>) resp.get("candidates");
+                if (candidates != null && !candidates.isEmpty()) {
+                    var contentMap = (Map<String, Object>) candidates.get(0).get("content");
+                    if (contentMap != null) {
+                        var parts = (List<Map<String, Object>>) contentMap.get("parts");
+                        if (parts != null && !parts.isEmpty()) {
+                            Object textObj = parts.get(0).get("text");
+                            if (textObj != null) out = textObj.toString();
+                        }
+                    }
+                }
+            }
 
-        // GPT 응답에서 허용된 코드를 최대 3개까지 반환
-        String out = Arrays.stream(raw.trim().split("[,\\s]+")) // 쉼표 및 공백 기준으로 쪼갬
-                .map(String::trim)                              // 양쪽 공백 제거
-                .filter(ALLOWED::contains)                      // 허용된 코드만
-                .distinct()                                     // 중복 제거
-                .limit(3)                                       // 최대 3개
-                .collect(Collectors.joining(","));              // 다시 쉼표로 합침
+            // 태그 정리 후 리턴하는데 아무것도 없으면 friendship을 반환해줌
+            String cleaned = normalize(out);
+            return cleaned.isBlank() ? "friendship" : cleaned;
 
-        // 최종 결과가 비었으면 default, 아니면 그대로 반환
-        return out.isBlank() ? "default" : out;
-         **/
+        } catch (Exception e) {
+            e.printStackTrace(); // 에러를 찍는 것임
+            return "friendship"; // 만약 실패했으면 friendship이 기본 default 값으로 반환됨
+        }
+    }
 
-        return "friendship"; // 테스트 시 GPT 호출 대신 더미 값 리턴
+    // ai가 준 문자열을 허용 목록에 맞게 정리해놓은 것임
+    private static String normalize(String raw) {
+        if (raw == null) return "";
+        return java.util.Arrays.stream(raw.trim().split("[,\\s]+"))         // 콤마나 공백으로 분리함
+                .map(String::trim)                                               // 공백을 제거함
+                .filter(ALLOWED::contains)                                       // 허용된 태그만 걸러지게 함
+                .distinct()                                                      // 중복을 제거함
+                .limit(3)                                                // 최대 3개까지만 나오게 함
+                .reduce((a, b) -> a + "," + b)                      // 합치는 것임
+                .orElse("");                                              // 없으면 빈 문자열이 나옴
     }
 }


### PR DESCRIPTION
Closes #3

## 변경 내용
- Emotion.java는 Gemini generateContent 호출 로직 및 응답을 파싱했고, 태그를 정규화 하는 부분 추가해놓음
- HttpClientsConfig.java는 Gemini WebClient 구성 즉,  API Key 쿼리 파라미터를 구성해놨고 Kakao 클라이언트는 일단 유지 시킴
- 실패 및 예외 시 기본값으로 `friendship` 반환되게 해놓음

## 테스트
- Swagger POST /posts로 emotions는 비어두고 content만 입력하면 emotions가 자동 분류됨
- GET /posts/{id}에서 분류 결과 확인가능함 (예: "lonely,friendship")
