### PR TITLE
cors 추가

### DIFF
--- a/src/main/java/com/emomap/emomap/common/security/SecurityConfig.java
+++ b/src/main/java/com/emomap/emomap/common/security/SecurityConfig.java
@@ -13,6 +13,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -23,6 +29,22 @@ public class SecurityConfig {
 
     @Value("${spring.jwt.secretKey}")
     private String secretKey;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization","Location","Link"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -36,6 +58,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(new JwtTokenFilter(userService, secretKey), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",


### PR DESCRIPTION
### 작업 배경
- 배포 환경에서도 원활한 API 호출을 위해 CORS 허용 설정 추가

### 작업 내용
- SecurityConfig.java에 전역 CORS 설정 추가
  - 모든 Origin 허용 (`setAllowedOriginPatterns("*")`)
  - 모든 HTTP Method 허용 (GET, POST, PUT, PATCH, DELETE, OPTIONS)
  - 모든 Header 허용
  - Authorization, Location, Link 헤더 노출
  - Credentials 허용
- OPTIONS 요청에 대해 SecurityFilterChain에서 `permitAll` 처리

### 관련 이슈
- Closes #10
